### PR TITLE
FIX: Viser ikke TY for SVP når ingen perioder har tilkjent dagsats

### DIFF
--- a/packages/fp-behandling-forstegang-og-revurdering/src/behandlingsprosess/definition/svangerskapspengerBpDefinition.jsx
+++ b/packages/fp-behandling-forstegang-og-revurdering/src/behandlingsprosess/definition/svangerskapspengerBpDefinition.jsx
@@ -8,7 +8,14 @@ import vut from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
 import getStatusFromSimulering from './simuleringStatusUtleder';
 import getVedtakStatus from './vedtakStatusUtleder';
 
-const getStatusFromResultatstruktur = ({ resultatstruktur }) => (resultatstruktur && resultatstruktur.perioder.length > 0 ? vut.OPPFYLT : vut.IKKE_VURDERT);
+const harMinstEnPeriodeMedInnvilgedePenger = (resultatstruktur) => resultatstruktur.perioder.filter((p) => p.dagsats > 0).length > 0;
+
+const getStatusFromResultatstruktur = ({ resultatstruktur }) => {
+  if (!resultatstruktur || !resultatstruktur.perioder) {
+    return vut.IKKE_VURDERT;
+  }
+  return harMinstEnPeriodeMedInnvilgedePenger(resultatstruktur) ? vut.OPPFYLT : vut.IKKE_VURDERT;
+};
 
 const hasNonDefaultBehandlingspunkt = (builderData, bpLength) => bpLength > 0;
 

--- a/packages/fp-behandling-forstegang-og-revurdering/src/behandlingsprosess/definition/svangerskapspengerBpDefinition.spec.jsx
+++ b/packages/fp-behandling-forstegang-og-revurdering/src/behandlingsprosess/definition/svangerskapspengerBpDefinition.spec.jsx
@@ -213,4 +213,92 @@ describe('Definisjon av behandlingspunkter - Svangerskapspenger', () => {
 
     expect(bpPropList).to.eql([]);
   });
+
+  it('skal alltid vise behandlingspunktene for beregning, tilkjent-ytelse og vedtak når det finnes minst ett annet behandlingspunkt', () => {
+    const builderData = {
+      behandlingType: {
+        kode: behandlingType.FORSTEGANGSSOKNAD,
+      },
+      vilkar: [sokersOpplysningspliktVilkar],
+      aksjonspunkter: [],
+      behandlingsresultat: {},
+      resultatstruktur: undefined,
+      stonadskontoer: undefined,
+      featureToggles,
+    };
+
+    const bpPropList = createSvangerskapspengerBpProps(builderData);
+
+    expect(bpPropList).to.eql([sokersOpplysningspliktBehandlingspunkt, ...defaultBehandlingspunkter]);
+  });
+
+  it('skal ikke vise tilkjent ytelse når ingen perioder har tildelt dagsats', () => {
+    const resultatstruktur = {
+      perioder: [
+        {
+          status: 'INNVILGET',
+          dagsats: 0,
+        },
+        {
+          status: 'INNVILGET',
+          dagsats: 0,
+        },
+        {
+          status: 'INNVILGET',
+          dagsats: 0,
+        },
+      ],
+    };
+    const builderData = {
+      behandlingType: {
+        kode: behandlingType.FORSTEGANGSSOKNAD,
+      },
+      vilkar: [sokersOpplysningspliktVilkar],
+      aksjonspunkter: [],
+      behandlingsresultat: {},
+      stonadskontoer: undefined,
+      featureToggles,
+      resultatstruktur,
+    };
+
+    const bpPropList = createSvangerskapspengerBpProps(builderData);
+
+    expect(bpPropList).to.eql([sokersOpplysningspliktBehandlingspunkt, ...defaultBehandlingspunkter]);
+  });
+
+  it('skal vise tilkjent ytelse når minst en periode har tildelt dagsats', () => {
+    const resultatstruktur = {
+      perioder: [
+        {
+          status: 'INNVILGET',
+          dagsats: 0,
+        },
+        {
+          status: 'INNVILGET',
+          dagsats: 0,
+        },
+        {
+          status: 'INNVILGET',
+          dagsats: 1,
+        },
+      ],
+    };
+    const builderData = {
+      behandlingType: {
+        kode: behandlingType.FORSTEGANGSSOKNAD,
+      },
+      vilkar: [sokersOpplysningspliktVilkar],
+      aksjonspunkter: [],
+      behandlingsresultat: {},
+      stonadskontoer: undefined,
+      featureToggles,
+      resultatstruktur,
+    };
+
+    const bpPropList = createSvangerskapspengerBpProps(builderData);
+
+    defaultBehandlingspunkter[1].status = vilkarUtfallType.OPPFYLT;
+
+    expect(bpPropList).to.eql([sokersOpplysningspliktBehandlingspunkt, ...defaultBehandlingspunkter]);
+  });
 });


### PR DESCRIPTION
## Tilhørende brukerhistorier


## Vises for saksbehandler
- [x] Ja
- [] Nei

## Strategi for funksjonsbryter
- [x] Ikke funskjonsbryter
- [] Funksjonsbryter

## Beskrivelse
Lar ikke TY være klikkbar hvis ingen av periodene har fått tilegnet dagsats

## Hvordan treffer det lansert funksjonalitet?
Fikser feil i TY

## Hvilket område berører endringen?
Tilkjent Ytelse

## Regresjonstest
- [] Ja
- [x] Nei
